### PR TITLE
fix(bundle): add default value '/' to options.inputDir

### DIFF
--- a/core/bundle.js
+++ b/core/bundle.js
@@ -1,7 +1,9 @@
 const fs = require("fs")
 const { promises } = fs
 const Path = require("path")
-const options = {}
+const options = {
+  inputDir: '/'
+}
 
 module.exports = async function build(main) {
   const rootJson = await resolveAsset(Path.resolve(main || ""))


### PR DESCRIPTION
an error occurred when running `run start`
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
```
it is generated by running `resolveAsset` for the first time

add default value '/' to `options.inputDir` can fix this problem